### PR TITLE
Do not replace $NODE in /etc/rc.local, get definition from allstar.env

### DIFF
--- a/asl3_sayip_reboot_halt.sh
+++ b/asl3_sayip_reboot_halt.sh
@@ -29,7 +29,7 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-NODE=$1
+NODE_NUMBER=$1
 
 CONF_FILE="/etc/asterisk/rpt.conf"
 BASE_URL="https://dev.gentoo.org/~anarchy/asl3-scripts"
@@ -109,10 +109,10 @@ fi
 
 cp "$CONF_FILE" "${CONF_FILE}.bak"
 sed -i "/\\[functions\\]/a \\
-A1 = cmd,/etc/asterisk/local/sayip.sh $NODE \\
-A3 = cmd,/etc/asterisk/local/saypublicip.sh $NODE \\
-B1 = cmd,/etc/asterisk/local/halt.sh $NODE \\
-B3 = cmd,/etc/asterisk/local/reboot.sh $NODE \\
+A1 = cmd,/etc/asterisk/local/sayip.sh $NODE_NUMBER \\
+A3 = cmd,/etc/asterisk/local/saypublicip.sh $NODE_NUMBER \\
+B1 = cmd,/etc/asterisk/local/halt.sh $NODE_NUMBER \\
+B3 = cmd,/etc/asterisk/local/reboot.sh $NODE_NUMBER \\
 " "$CONF_FILE"
 
-echo "ASL3 now has support for sayip/reboot/halt configured for node $NODE..."
+echo "ASL3 now has support for sayip/reboot/halt configured for node $NODE_NUMBER..."

--- a/asl3_sayip_reboot_halt.sh
+++ b/asl3_sayip_reboot_halt.sh
@@ -87,7 +87,7 @@ fi
 
 if [ \"\$(echo \"\${SAY_IP_AT_BOOT}\" | tr \"[:upper:]\" \"[:lower:]\")\" = \"enabled\" ]; then
     sleep 12
-    /etc/asterisk/local/sayip.sh \"$NODE\"
+    /etc/asterisk/local/sayip.sh \"\$NODE\"
 fi
 "
 

--- a/asl3_sayip_reboot_halt.sh
+++ b/asl3_sayip_reboot_halt.sh
@@ -65,7 +65,7 @@ cat <<EOF > /etc/asterisk/local/allstar.env
 #!/bin/sh
 
 # defines the primary node (node) number
-export NODE=$NODE
+export NODE=$NODE_NUMBER
 
 # Defines saying of local IP address at boot (enabled or disabled)
 # Default: "enabled"


### PR DESCRIPTION
Fixes small issue where $NODE was being replaced in rc.local instead of using the definition via allstar.env