### PR TITLE
Drop rc.local hack and add a systemd unit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ sudo ./asl3_sayip_reboot_halt.sh YOUR_NODE_NUMBER
 ```
 If you do not wish to have your node speak its Local IP address upon boot you can simply disable it
 ```
-sudo nano -w /etc/asterisk/local/allstar.env 
-```
+sudo systemctl disable allstar-sayip``
+````
 
 
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ sudo ./asl3_sayip_reboot_halt.sh YOUR_NODE_NUMBER
 ```
 If you do not wish to have your node speak its Local IP address upon boot you can simply disable it
 ```
-sudo systemctl disable allstar-sayip``
-````
+sudo systemctl disable allstar-sayip
+```
 
 
 


### PR DESCRIPTION
Simply drops the rc.local hack and adds a systemd unit file to control announcement upon bootup.

README has been updated to correlate the change of using the systemd unit file.