### PR TITLE
Sleep for 5 seconds before we announce

### DIFF
--- a/asl3_sayip_reboot_halt.sh
+++ b/asl3_sayip_reboot_halt.sh
@@ -68,7 +68,7 @@ Requires=asterisk.service
 
 [Service]
 Type=oneshot
-ExecStart=/etc/asterisk/local/sayip.sh $NODE_NUMBER
+ExecStart=/bin/bash -c 'sleep 5s && /etc/asterisk/local/sayip.sh $NODE_NUMBER'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
We need to sleep 5 seconds before we announce, this allows asterisk to id before we try to announce the ip address.